### PR TITLE
Updated kotlin gradle plugin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.timoteohss.slide_button'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
The rather old kotlin-gradle-plugin version 1.2.71 can cause builds to fail.  
This PR updates the version to 1.3.61.