### PR TITLE
Fix to prevent OnButtonOpened to be called twice

### DIFF
--- a/lib/slide_button.dart
+++ b/lib/slide_button.dart
@@ -198,7 +198,7 @@ class _SlideButtonState extends State<SlideButton>
   void _onDragEnd(DragEndDetails details) {
     if (_slideAC.isAnimating) return;
 
-    if (_slideAC.value > widget.confirmPercentage) {
+    if (_slideAC.value > widget.confirmPercentage && _slideAC.value < 1.0) {
       _slideAC.fling(velocity: 1.0);
     } else {
       _slideAC.animateTo(widget.initialSliderPercentage,


### PR DESCRIPTION
To reproduce the issue :
Add an OnButtonOpened call back to the button and drag it until the end release you will see that the callback is being called twice, once when you reach 1.0 manually and the other one when the animator fling it to 1.0 again (even when it's already 1.0).

Source fo the issue :
The source of the error is that the button is being flung anyways when it reaches the confirmPercentage even when it's already at 1.0

The fix :
To fix the issue, added a check before flinging. So the only case when to fling is when the button has been dragged to less than 1.0 but reached the confirmationPercentage.